### PR TITLE
Checks for DBPATH in the environment, and uses that for the DB location.

### DIFF
--- a/script.MyOSMC/resources/lib/database/osmcprefs.py
+++ b/script.MyOSMC/resources/lib/database/osmcprefs.py
@@ -1,5 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import sys
+import os
 
 from dbinterface import DBInterface
 
@@ -9,11 +12,8 @@ DATABASE_PATH = "/home/osmc/.myosmc/preferences.db"
 def get_all_settings(provided_db=None):
 
     response = []
-    global DATABASE_PATH
 
-    DATABASE_PATH = provided_db if provided_db is not None else DATABASE_PATH
-
-    kv = DBInterface(DATABASE_PATH).all_pairs().items()
+    kv = DBInterface(provided_db).all_pairs().items()
     response.append('%-20s %-20s' % ('\n Key', ' Value'))
     response.append('-------------------- --------------------')
     kv.sort()
@@ -25,37 +25,30 @@ def get_all_settings(provided_db=None):
 
 def get_setting(key, provided_db=None):
 
-    global DATABASE_PATH
-
-    DATABASE_PATH = provided_db if provided_db is not None else DATABASE_PATH
-
     try:
-        return DBInterface(dbpath=DATABASE_PATH).getsetting(key)
+        return DBInterface(dbpath=provided_db).getsetting(key)
     except KeyError:
         return "KeyError: Key not found in database"
 
 
 def osmcprefs(args, provided_db=None):
-    global DATABASE_PATH
-
-    DATABASE_PATH = provided_db if provided_db is not None else DATABASE_PATH
 
     response = []
 
     if len(args) <= 1:
 
         if args[0].lower().endswith('osmc_getperfs'):
-            response = get_all_settings(provided_db=DATABASE_PATH)
+            response = get_all_settings(provided_db=provided_db)
         else:
             response.append('add help')
 
     elif len(args) == 2:
         if args[1] == '-a':
-            response = get_all_settings(provided_db=DATABASE_PATH)
+            response = get_all_settings(provided_db=provided_db)
 
         else:
             # process a GET request using the default db location
-            r = get_setting(args[1], provided_db=DATABASE_PATH)
+            r = get_setting(args[1], provided_db=provided_db)
             response.append(str(r))
 
     elif len(args) == 3:  # No magic needed for osmc_setprefs, as it will still have 3 args
@@ -63,15 +56,15 @@ def osmcprefs(args, provided_db=None):
         key = args[1]
         value = args[2]
         if value.lower() in ['true', 'false']:
-            DBInterface(dbpath=DATABASE_PATH).setsetting(key, bool(value), bool)
+            DBInterface(dbpath=provided_db).setsetting(key, bool(value), bool)
         else:
             try:
-                DBInterface(dbpath=DATABASE_PATH).setsetting(key, int(value), int)
+                DBInterface(dbpath=provided_db).setsetting(key, int(value), int)
             except ValueError:
                 try:
-                    DBInterface(dbpath=DATABASE_PATH).setsetting(key, float(value), float)
+                    DBInterface(dbpath=provided_db).setsetting(key, float(value), float)
                 except ValueError:
-                    DBInterface(dbpath=DATABASE_PATH).setsetting(key, value)
+                    DBInterface(dbpath=provided_db).setsetting(key, value)
         response.append('Set "%s" as "%s"' % (args[1], args[2]))
 
     else:
@@ -82,5 +75,6 @@ def osmcprefs(args, provided_db=None):
 
 if __name__ == '__main__':   # pragma: no cover
 
-    # DATABASE_PATH='C:\\t\\test.db'
-    print(osmcprefs(sys.argv))
+    dbpath = os.environ['DBPATH'] if 'DBPATH' in os.environ else DATABASE_PATH
+
+    print(osmcprefs(sys.argv, provided_db=dbpath))


### PR DESCRIPTION
Running as ./osmcprefs.py uses the default database; env DBPATH=somepath/test.db ./osmcprefs.py uses the DBPATH value.